### PR TITLE
fix: add space on bottom for image branding iOS

### DIFF
--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -386,21 +386,21 @@ const String _iOSLaunchBackgroundConstraints = '''
 const String _iOSBrandingCenterBottomConstraints = '''
 <constraints>
   <constraint firstItem="Uyq-Kz-ftE" firstAttribute="centerX" secondItem="YRO-k0-Ey4" secondAttribute="centerX" id="3kg-TC-cPP"/>
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom"  id="8Yb-q4-8bl"/>
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8bl"/>
 </constraints>
 ''';
 
 const String _iOSBrandingLeftBottomConstraints = '''
 <constraints>
   <constraint firstAttribute="leading" secondItem="Uyq-Kz-ftE" secondAttribute="leading" id="3kg-TC-cPP"/>
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" id="8Yb-q4-8bl"/>
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8bl"/>
 </constraints>
 ''';
 
 const String _iOSBrandingRightBottomConstraints = '''
 <constraints>
   <constraint firstAttribute="trailing" secondItem="Uyq-Kz-ftE" secondAttribute="trailing" id="3kg-TC-cPP"/>                            
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" id="8Yb-q4-8lb"/>                            
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8lb"/>                            
 </constraints>
 ''';
 


### PR DESCRIPTION
## What it does

- add bottom space for iOS branding image regarding this issue https://github.com/jonbhanson/flutter_native_splash/issues/694

## How to test

1. follow this documentation to run and generate the native splash-screen
2. enable branding image
3. observe the branding image position

## Screenshot

#### iPhone 15 Pro Max 
![image](https://github.com/Lzyct/flutter_native_splash/assets/1531684/49ef6d58-8e45-49ac-9747-eb0a42e74a46)


### iPhone SE
![image](https://github.com/Lzyct/flutter_native_splash/assets/1531684/bc8238b2-c9e2-471d-8834-494fa049448d)

