### PR TITLE
fix: add space 24 for image branding android

### DIFF
--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -9,7 +9,7 @@ const String _androidLaunchItemXml = '''
 ''';
 
 const String _androidBrandingItemXml = '''
-    <item>
+    <item android:bottom="24dp">
         <bitmap android:gravity="center" android:src="@drawable/branding" />
     </item>
 ''';


### PR DESCRIPTION
## What it does

- add bottom space for < Android  13

## How to test

1. follow this documentation to run and generate the native splash-screen
2. enable branding image
3. observe the branding image position

## Screenshot

#### Android API 29
![image](https://github.com/Lzyct/flutter_native_splash/assets/1531684/18a666a1-a76c-4e33-bdc7-db65858e4c21)


